### PR TITLE
make leave idempotent

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ build:
     - tar -xzf tarantool-enterprise-bundle-${BUNDLE_VERSION}.tar.gz
     - rm -rf tarantool-enterprise-bundle-${BUNDLE_VERSION}.tar.gz
     - export PATH=$PWD/tarantool-enterprise:$PATH
-    - yum -y install https://centos7.iuscommunity.org/ius-release.rpm
+    - yum -y install https://repo.ius.io/ius-release-el7.rpm
     - yum -y install git gcc make cmake unzip python36u-pip
     - tarantoolctl rocks install ldoc --server=http://rocks.moonscript.org
     - tarantoolctl rocks install luacheck

--- a/membership.lua
+++ b/membership.lua
@@ -626,6 +626,9 @@ end
 local function leave()
     -- First, we need to stop all fibers
     local sock = _sock
+    if sock == nil then
+        return false
+    end
     _sock = nil
 
     -- Perform artificial events.generate() and instantly send it

--- a/membership.lua
+++ b/membership.lua
@@ -622,13 +622,16 @@ end
 -- The node will be marked with the status `left`
 -- and no other members will ever try to reconnect it.
 -- @function leave
--- @treturn boolean `true`
+-- @treturn boolean
+--  `true` if call succeeds,
+--  `false` if member has already left.
 local function leave()
-    -- First, we need to stop all fibers
-    local sock = _sock
-    if sock == nil then
+    if _sock == nil then
         return false
     end
+
+    -- First, we need to stop all fibers
+    local sock = _sock
     _sock = nil
 
     -- Perform artificial events.generate() and instantly send it

--- a/test/test_quit.py
+++ b/test/test_quit.py
@@ -17,6 +17,7 @@ def test_join(servers, helpers):
 def test_quit(servers, helpers):
     assert servers[13302].conn.eval('return membership.leave()')[0]
     helpers.wait_for(check_status, [servers[13301], 'localhost:13302', 'left'])
+    assert servers[13302].conn.eval('return membership.leave()')[0] is False
 
 
 def test_rejoin(servers, helpers):


### PR DESCRIPTION
Before this patch if user call membership.leave twice it obtain an
error. This patch handle this case properly.

Closes #14