### PR TITLE
Collect garbage subscriptions automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Make subscriptions garbage-collectible. Previously, `fiber.cond`
+  objects obtained from `membership.subscribe` should have been
+  unsubscribed manually, otherwise, they would never be GC'ed.
+  And now they are.
+
 ## [2.2.0] - 2019-10-22
 
 ### Added

--- a/membership/events.lua
+++ b/membership/events.lua
@@ -23,6 +23,7 @@ local _expired = {
 local _subscribers = {
     -- [fiber.cond] = true
 }
+setmetatable(_subscribers, {__mode = 'k'})
 
 function events.clear()
     _all_events = {}

--- a/test/test_subscribe.py
+++ b/test/test_subscribe.py
@@ -10,3 +10,14 @@ def test_subscribe(servers, helpers):
     assert not servers[13301].conn.eval('return _G.cond:wait(1)')[0]
     assert servers[13302].conn.eval('return membership.set_payload("foo", "bar")')[0]
     assert servers[13301].conn.eval('return _G.cond:wait(1)')[0]
+
+
+def test_weakness(servers, helpers):
+    assert servers[13301].conn.eval('''
+        local weaktable = setmetatable({}, {__mode = 'k'})
+        weaktable[_G.cond] = true
+        _G.cond = nil
+        collectgarbage()
+        collectgarbage()
+        return next(weaktable)
+    ''')[0] is None


### PR DESCRIPTION
Make subscriptions garbage-collectible. Previously, `fiber.cond` objects obtained from `membership.subscribe` should have been unsubscribed manually, otherwise, they would never be GC'ed. And now they are.