### PR TITLE
Handle code hot-reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Allow reloading the code on the fly without status intervention.
+
 ### Fixed
 
 - Make subscriptions garbage-collectible. Previously, `fiber.cond`

--- a/README.md
+++ b/README.md
@@ -41,3 +41,12 @@ timestamp: 1522427330993752
 clock_delta: 27810
 ...
 ```
+
+## Reloadability
+
+Membership module supports hot-reload:
+
+```lua
+package.loaded['membership'] = nil
+require('membership')
+```

--- a/membership-scm-1.rockspec
+++ b/membership-scm-1.rockspec
@@ -27,6 +27,7 @@ build = {
     install = {
         lua = {
             ['membership'] = 'membership.lua',
+            ['membership.stash'] = 'membership/stash.lua',
             ['membership.events'] = 'membership/events.lua',
             ['membership.members'] = 'membership/members.lua',
             ['membership.options'] = 'membership/options.lua',

--- a/membership/members.lua
+++ b/membership/members.lua
@@ -3,9 +3,10 @@ local checks = require('checks')
 local msgpack = require('msgpack')
 
 local opts = require('membership.options')
+local stash = require('membership.stash')
 
 local members = {}
-local _all_members = {
+local _all_members = table.copy(stash.get('members._all_members')) or {
     -- [uri] = {
     --     status = number,
     --     incarnation = number,
@@ -16,6 +17,10 @@ local _all_members = {
 
     -- uri is a string in format '<host>:<port>'
 }
+
+function members.after_reload()
+    stash.set('members._all_members', _all_members)
+end
 
 function members.clear()
     table.clear(_all_members)

--- a/membership/options.lua
+++ b/membership/options.lua
@@ -1,8 +1,18 @@
-#!/usr/bin/env tarantool
-
-local options = {}
 local log = require('log')
 local cbc = require('crypto').cipher.aes256.cbc
+
+local stash = require('membership.stash')
+
+local options = stash.get('options')
+if options == nil then
+    options = {}
+else
+    options = setmetatable(table.copy(options), nil)
+end
+
+function options.after_reload()
+    stash.set('options', options)
+end
 
 --- Tuning options for membership module.
 -- This module should normally never be used
@@ -51,7 +61,8 @@ options.NUM_FAILURE_DETECTION_SUBGROUPS = 3
 -- Default is 1472 (`Default-MTU (1500) - IP-Header (20) - UDP-Header (8)`)
 options.MAX_PACKET_SIZE = 1472
 
-options.ENCRYPTION_INIT = 'init-key-16-byte' -- !!KEEP string len SYNCED with cryptoapi
+--- Initialization vector for aes256 CBC encryption.
+options.ENCRYPTION_INIT = 'init-key-16-byte'
 
 function options.get_encryption_key()
     return options.encryption_key

--- a/membership/stash.lua
+++ b/membership/stash.lua
@@ -1,0 +1,41 @@
+local S = rawget(_G, '__membership_stash') or {}
+
+local function f_body(fn_name, ...)
+    local fiber = require('fiber')
+    while true do
+        S[fn_name](...)
+        fiber.testcancel()
+    end
+end
+
+assert(
+    debug.getinfo(f_body, 'u').nups == 1,
+    'Exceess closure upvalue'
+)
+
+local function fiber_new(fn_name, ...)
+    if not S[fn_name] then
+        error(('function %s not implemented'):format(fn_name), 2)
+    end
+
+    local k = 'fiber.' .. fn_name
+    S[k] = require('fiber').new(f_body, fn_name, ...)
+    return S[k]
+end
+
+local function fiber_cancel(fn_name)
+    local k = 'fiber.' .. fn_name
+    if S[k] ~= nil and S[k]:status() ~= 'dead' then
+        S[k]:cancel()
+        S[k] = nil
+    end
+end
+
+rawset(_G, '__membership_stash', S)
+
+return {
+    get = function(k) return S[k] end,
+    set = function(k, v) S[k] = v end,
+    fiber_new = fiber_new,
+    fiber_cancel = fiber_cancel,
+}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -97,7 +97,7 @@ class Server(object):
     def consume_lines(self):
         with self.process.stdout as pipe:
             for line in iter(pipe.readline, b''):
-                l = line.strip().decode('utf-8')  # noqa: E741
+                l = line.rstrip().decode('utf-8')  # noqa: E741
                 self.logger.warning(l)
                 if 'stack traceback:' in l:
                     self.seen_traceback = True

--- a/test/instance.lua
+++ b/test/instance.lua
@@ -2,7 +2,10 @@
 
 require('strict').on()
 local log = require('log')
+local fiber = require('fiber')
 local console = require('console')
+local membership = require('membership')
+_G.membership = membership
 
 if rawget(_G, "is_initialized") == nil then
     _G.is_initialized = false
@@ -11,9 +14,10 @@ end
 local listen = os.getenv('TARANTOOL_LISTEN')
 local hostname = os.getenv('TARANTOOL_HOSTNAME') or 'localhost'
 
-local console_sock = '127.0.0.1:'..listen
-console.listen(console_sock)
-log.info('Console started at %s', console_sock)
+if not _G.is_initialized then
+    local c = console.listen('127.0.0.1:'..listen)
+    log.info('Console started at %s:%s', c:name().host, c:name().port)
+end
 
 -- Tune periods to speed up tests
 -- Supposing loopback roundtrip is about 0.1ms
@@ -23,27 +27,41 @@ opts.ACK_TIMEOUT_SECONDS = 0.1
 opts.ANTI_ENTROPY_PERIOD_SECONDS = 2
 opts.SUSPECT_TIMEOUT_SECONDS = 2
 
--- Monkeypatch socket library to validate MAX_PACKET_SIZE
-local socket_lib = require('socket')
+if not _G.is_initialized then
+    -- Monkeypatch socket library to validate MAX_PACKET_SIZE
+    local socket_lib = require('socket')
 
-local socket_mt = getmetatable(socket_lib)
-local create_socket = socket_mt.__call
-socket_mt.__call = function(...)
-    log.error('Monkeypatching socket')
-    local sock = create_socket(...)
-    local sendto = sock.sendto
-    function sock.sendto(self, host, port, msg)
-        if #msg > opts.MAX_PACKET_SIZE then
-            log.error('Packet too big, %d > %d', #msg, opts.MAX_PACKET_SIZE)
-            os.exit(220)
+    local socket_mt = getmetatable(socket_lib)
+    local create_socket = socket_mt.__call
+    socket_mt.__call = function(...)
+        log.error('Monkeypatching socket')
+        local sock = create_socket(...)
+        local sendto = sock.sendto
+        function sock.sendto(self, host, port, msg)
+            if #msg > opts.MAX_PACKET_SIZE then
+                log.error('Packet too big, %d > %d', #msg, opts.MAX_PACKET_SIZE)
+                os.exit(220)
+            end
+            return sendto(self, host, port, msg)
         end
-        return sendto(self, host, port, msg)
-    end
 
-    return sock
+        return sock
+    end
 end
 
-local membership = require('membership')
-_G.membership = membership
 membership.init(hostname, tonumber(listen))
 _G.is_initialized = true
+
+_G.package.reload = function()
+    local csw1 = fiber.info()[fiber.id()].csw
+
+    package.loaded['membership'] = nil
+    log.info('Doing file %s...', arg[0])
+    dofile(arg[0])
+
+    local csw2 = fiber.info()[fiber.id()].csw
+    assert(csw1 == csw2, 'Unexpected yield')
+
+    log.info('Dofile succeeded')
+    return true
+end

--- a/test/test_reload.py
+++ b/test/test_reload.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+servers_list = [13301, 13302]
+
+
+def test_reload_slow(servers, helpers):
+    """ Check that hot-reload doesn't affect statuses """
+
+    assert servers[13301].probe_uri('localhost:13302') is True
+    assert servers[13302].get_member('localhost:13301')['status'] == 'alive'
+
+    servers[13302].conn.eval('''
+        local log = require('log')
+        local yaml = require('yaml')
+        local fiber = require('fiber')
+
+        _G.guard = fiber.new(function()
+            membership.subscribe():wait()
+            fiber.testcancel()
+            log.error('Unexpected event:')
+            log.error(yaml.encode(membership.members()))
+            os.exit(1)
+        end)
+    ''')
+
+    assert servers[13301].conn.eval('''
+        local log = require('log')
+        local fiber = require('fiber')
+
+        package.loaded['membership'] = nil
+        log.info('Membership unloaded')
+        fiber.sleep(1)
+
+        _G.membership = require('membership')
+        log.info('Membership reloaded')
+        fiber.sleep(1)
+
+        log.info('Doing file %s...', arg[0])
+        dofile(arg[0])
+        log.info('Dofile succeeded')
+        fiber.sleep(1)
+
+        return membership.probe_uri('localhost:13302')
+    ''') == [True]
+
+    servers[13302].conn.eval('''
+        _G.guard:cancel()
+    ''')
+
+
+def test_reload_fast(servers, helpers):
+    """ Check that hot-reload doesn't affect other features """
+
+    assert servers[13301].probe_uri('localhost:13302') is True
+    assert servers[13302].get_member('localhost:13301')['status'] == 'alive'
+
+    assert servers[13301].conn.eval('return package.reload()') == [True]
+
+    assert servers[13302].conn.eval('return membership.set_payload("k", "v1")')[0]
+    assert servers[13302].probe_uri('localhost:13301') is True
+    assert servers[13301].members()['localhost:13302']['payload'] == {'k': 'v1'}
+
+    servers[13301].conn.eval('_G.cond = membership.subscribe()')
+    assert servers[13301].conn.eval('return package.reload()') == [True]
+    assert servers[13302].conn.eval('return membership.set_payload("k", "v2")')[0]
+    assert servers[13301].conn.eval('return _G.cond:wait(1)')[0]
+    assert servers[13301].members()['localhost:13302']['payload'] == {'k': 'v2'}
+
+    def check_status(srv, uri, status):
+        member = srv.members()[uri]
+        assert member['status'] == status
+
+    servers[13302].conn.eval('return membership.set_encryption_key("YY")')
+    assert servers[13302].conn.eval('return package.reload()') == [True]
+    helpers.wait_for(check_status, [servers[13301], 'localhost:13302', 'non-decryptable'])
+    helpers.wait_for(check_status, [servers[13302], 'localhost:13301', 'non-decryptable'])
+
+    servers[13301].conn.eval('return membership.set_encryption_key("YY")')
+    helpers.wait_for(check_status, [servers[13301], 'localhost:13302', 'alive'])
+    helpers.wait_for(check_status, [servers[13302], 'localhost:13301', 'alive'])


### PR DESCRIPTION
Code swap technique implies unloading the old module code by setting `package.loaded[module] = nil` and subsequently `require()` it again.

To make it smooth and to avoid status intervention one has to persist some data across reload though - the socket object, members, events, running fibers. But fiber code should be updated too. So there is a new Lua module stash which is used to store all those things. A fiber body with an infinite loop is implemented with the only closure on that stash, and the real logic is stored there.
