### PR TITLE
Fix pytest warnings

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -89,7 +89,7 @@ class Server(object):
         env['TARANTOOL_LISTEN'] = str(self.port)
 
         cmd = ["tarantool", os.path.join(script_dir, 'instance.lua')]
-        self.process = Popen(cmd, stdout=PIPE, stderr=STDOUT, env=env, bufsize=1)
+        self.process = Popen(cmd, stdout=PIPE, stderr=STDOUT, env=env)
         self.thread = Thread(
             target=self.consume_lines
         ).start()


### PR DESCRIPTION
Just remove the buffer argument from Popen. Anyway, the default value is used.

```
test/test_init.py::test_join
  /opt/hostedtoolcache/Python/3.8.9/x64/lib/python3.8/subprocess.py:848:
    RuntimeWarning: line buffering (buffering=1) isn't supported in binary
    mode, the default buffer size will be used
  self.stdout = io.open(c2pread, 'rb', bufsize)
```

Docs: https://docs.pytest.org/en/latest/warnings.html
