### PR TITLE
Fix exception in nslookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Uncaught exception which prevented discovering
+  non-decryptable members.
+
 ## [2.3.2] - 2021-04-22
 
 ### Fixed

--- a/membership.lua
+++ b/membership.lua
@@ -89,7 +89,10 @@ local function nslookup(host, port)
     checks('string', 'number')
 
     for uri, cache in pairs(_resolve_cache) do
-        if (cache.host == host) and (cache.port == port) then
+        if cache
+        and cache.host == host
+        and cache.port == port
+        then
             return uri
         end
     end


### PR DESCRIPTION
There was a bug in `nslookup` function which prevented discovering non-decryptable members. This patch fixes it.

Close #36 