### PR TITLE
Add internal option to stop producing suspects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- New option `SUSPICIOUSNESS` (default: `true`) allows to
+  disable generation of rumors about suspected members.
+
 ### Fixed
 
 - Uncaught exception which prevented discovering

--- a/membership.lua
+++ b/membership.lua
@@ -508,8 +508,14 @@ local function _protocol_step()
         members.set(uri, member.status, member.incarnation, { clock_delta = delta })
         return
     elseif members.get(uri).status == opts.ALIVE then
-        log.info('Could not reach node: %s - %s', uri, opts.STATUS_NAMES[opts.SUSPECT])
-        events.generate(uri, opts.SUSPECT)
+        if opts.SUSPICIOUSNESS == false then
+            log.debug('Could not reach node: %s (ignored)', uri)
+        else
+            log.info('Could not reach node: %s - %s', uri,
+                opts.STATUS_NAMES[opts.SUSPECT]
+            )
+            events.generate(uri, opts.SUSPECT)
+        end
         return
     end
 end

--- a/membership/options.lua
+++ b/membership/options.lua
@@ -45,6 +45,13 @@ options.ACK_TIMEOUT_SECONDS = 0.200
 -- Default is 10
 options.ANTI_ENTROPY_PERIOD_SECONDS = 10.0
 
+--- Toggle producing `suspect` rumors when ping fails. Even if disabled,
+-- it doesn't affect neither gossip dissemination nor other statuses
+-- generation (e.g. `dead` and `non-decryptable`).
+--
+-- Default is `true`
+options.SUSPICIOUSNESS = true
+
 --- Timeout to mark `suspect` members as `dead`.
 --
 -- Default is 3

--- a/test/test_false_rumors.py
+++ b/test/test_false_rumors.py
@@ -70,3 +70,20 @@ def test_flickering(servers, helpers):
         'localhost:13302': 'suspect',
         'localhost:13303': 'suspect',
     }])
+
+
+def test_nonsuspiciousness(servers, helpers):
+    # With disabled suspiciousness it stops flickering again
+
+    servers[13301].conn.eval('''
+        local opts = require('membership.options')
+        opts.SUSPICIOUSNESS = false
+    ''')
+
+    helpers.wait_for(servers[13301].check_status, ['localhost:13301', 'alive'])
+    helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'alive'])
+    helpers.wait_for(servers[13301].check_status, ['localhost:13303', 'alive'])
+    servers[13301].conn.eval("table.clear(rumors)")
+
+    time.sleep(2)
+    check_rumors(servers[13301], {})


### PR DESCRIPTION
This patch adds a new option: `opts.SUSPICIOUSNESS = true`. When turned off, membership will stop producing rumors about suspected members. This option is intended to be used in Cartridge during a snapshot recovery which is known to be a heavy operation.

Part of #35 