### PR TITLE
Setup log verbosity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New option `SUSPICIOUSNESS` (default: `true`) allows to
   disable generation of rumors about suspected members.
 
+- New option `log_debug` which can be easily overridden to
+  control the verbosity level.
+
 ### Fixed
 
 - Uncaught exception which prevented discovering

--- a/membership.lua
+++ b/membership.lua
@@ -509,7 +509,7 @@ local function _protocol_step()
         return
     elseif members.get(uri).status == opts.ALIVE then
         if opts.SUSPICIOUSNESS == false then
-            log.debug('Could not reach node: %s (ignored)', uri)
+            opts.log_debug('Could not reach node: %s (ignored)', uri)
         else
             log.info('Could not reach node: %s - %s', uri,
                 opts.STATUS_NAMES[opts.SUSPECT]

--- a/membership/events.lua
+++ b/membership/events.lua
@@ -1,4 +1,3 @@
-local log = require('log')
 local fiber = require('fiber')
 local checks = require('checks')
 local msgpack = require('msgpack')
@@ -131,13 +130,13 @@ function events.handle(event)
 
     -- update members list
     if not member then
-        log.debug(
+        opts.log_debug(
             'Adding: %s (inc. %d) is %s',
             event.uri, event.incarnation,
             opts.STATUS_NAMES[event.status]
         )
     elseif member.status ~= event.status or member.incarnation ~= event.incarnation then
-        log.debug(
+        opts.log_debug(
             'Rumor: %s (inc. %d) is %s',
             event.uri, event.incarnation,
             opts.STATUS_NAMES[event.status]

--- a/membership/options.lua
+++ b/membership/options.lua
@@ -71,6 +71,9 @@ options.MAX_PACKET_SIZE = 1472
 --- Initialization vector for aes256 CBC encryption.
 options.ENCRYPTION_INIT = 'init-key-16-byte'
 
+
+options.log_debug = log.debug
+
 function options.get_encryption_key()
     return options.encryption_key
 end


### PR DESCRIPTION
This patch adds a new private option `options.log_debug = log.debug`. It will not be used by default, but I expect it may be useful when we try to debug a large cluster.