### PR TITLE
Dont produce pumors when myself is dead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - New option `SUSPICIOUSNESS` (default: `true`) allows to
-  disable generation of rumors about suspected members.
+  disable generation of rumors about suspected members. Also,
+  membership won't produce any rumors unless myself is alive.
 
 - New option `log_debug` which can be easily overridden to
   control the verbosity level.

--- a/membership.lua
+++ b/membership.lua
@@ -508,7 +508,10 @@ local function _protocol_step()
         members.set(uri, member.status, member.incarnation, { clock_delta = delta })
         return
     elseif members.get(uri).status == opts.ALIVE then
-        if opts.SUSPICIOUSNESS == false then
+        local myself = members.get(advertise_uri)
+        if myself.status ~= opts.ALIVE then
+            opts.log_debug('Could not reach node: %s (%s myself)', uri, myself.status)
+        elseif opts.SUSPICIOUSNESS == false then
             opts.log_debug('Could not reach node: %s (ignored)', uri)
         else
             log.info('Could not reach node: %s - %s', uri,


### PR DESCRIPTION
This is a follow-up for #42 (issue #35). In addition to the explicit flag, this patch implicitly disables suspiciousness in case the current instance is dead.

Close #35 