### PR TITLE
Fix log overflow when inner fibers weren't canceled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Log overflow when inner fibers weren't canceled.
+
 ## [2.4.0] - 2021-07-12
 
 ### Added

--- a/membership.lua
+++ b/membership.lua
@@ -364,11 +364,17 @@ local function handle_message(msg)
 end
 
 local function _handle_message_step()
+    if _sock == nil then
+        return
+    end
     local ok = _sock:readable(opts.PROTOCOL_PERIOD_SECONDS)
     if not ok then
         return
     end
 
+    if _sock == nil then
+        return false
+    end
     local msg, from = _sock:recvfrom(opts.MAX_PACKET_SIZE)
     local ok = handle_message(msg)
 

--- a/membership/stash.lua
+++ b/membership/stash.lua
@@ -1,5 +1,7 @@
 local S = rawget(_G, '__membership_stash') or {}
 
+local log = require('log')
+
 local function f_body(fn_name, ...)
     local fiber = require('fiber')
     while true do
@@ -26,7 +28,10 @@ end
 local function fiber_cancel(fn_name)
     local k = 'fiber.' .. fn_name
     if S[k] ~= nil and S[k]:status() ~= 'dead' then
-        S[k]:cancel()
+        local ok, err = pcall(S[k].cancel, S[k])
+        if not ok then
+            log.error('Fiber %s cancel error: %s', fn_name, err)
+        end
         S[k] = nil
     end
 end


### PR DESCRIPTION
If some of the inner membership fibers weren't canceled on instance graceful shutdown, it can lead to an unstoppable stream of log errors `attempt to index upvalue '_sock'`. I've added the additional socket check and logging on fiber cancel call.