### PR TITLE
fix(member.unpack): fix payload position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+ - Invalid payload parsing in anti entropy step.
+
 ## [2.4.3] - 2024-01-29
 
 ### Fixed

--- a/membership/members.lua
+++ b/membership/members.lua
@@ -55,7 +55,7 @@ end
 
 function members.unpack(member)
     checks('table')
-    local payload = member[3]
+    local payload = member[4]
     if payload == msgpack.NULL
     or type(payload) ~= 'table'
     then


### PR DESCRIPTION
Commit 7021e9f9209645d684b2cfcda9d63226cc1c7068 refactored members.unpack function but introduced a typo with the position of the payload in the array that forced payload to be ignored.

Such bug broke anti_entropy step, forcing incarnation to be updated and payload to be ignored, making instances view of each other inconsistent.

Closes #61