### PR TITLE
Add `mark_left` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `mark_left` function to mark removed members as `left`.
+
 ## [2.4.5] - 2024-06-24
 
 ### Fixed
@@ -13,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Invalid events parsing.
 
 ## [2.4.4] - 2024-04-09
+
 ### Fixed
 
 - Invalid payload parsing in anti entropy step.

--- a/membership.lua
+++ b/membership.lua
@@ -748,7 +748,7 @@ local function mark_left(uri_to_leave)
 
     -- Perform artificial events.generate() and instantly send it
     local myself = members.get(uri_to_leave)
-    if not myself then
+    if not myself or myself.status == opts.LEFT then
         return false
     end
     local event = events.pack({

--- a/membership.lua
+++ b/membership.lua
@@ -736,6 +736,39 @@ local function leave()
     return true
 end
 
+--- Forcefully send leave message about an instance.
+-- @function mark_left
+-- @treturn boolean
+--  `true` if call succeeds,
+--  `false` if member has already left.
+local function mark_left(uri_to_leave)
+    if _sock == nil then
+        return false
+    end
+
+    -- Perform artificial events.generate() and instantly send it
+    local myself = members.get(uri_to_leave)
+    if not myself then
+        return false
+    end
+    local event = events.pack({
+        uri = uri_to_leave,
+        status = opts.LEFT,
+        incarnation = myself.incarnation,
+        ttl = members.count(),
+    })
+    local msg_msgpacked = msgpack.encode({uri_to_leave, 'LEAVE', msgpack.NULL, {event}})
+    local msg_encrypted = opts.encrypt(msg_msgpacked)
+    for _, uri in ipairs(members.filter_excluding('unhealthy', uri_to_leave)) do
+        local addr = resolve(uri)
+        if addr then
+            _sock:sendto(addr.host, addr.port, msg_encrypted)
+        end
+    end
+
+    return true
+end
+
 --- Member data structure.
 -- A member is represented by the table with the following fields:
 --
@@ -984,6 +1017,7 @@ end
 return {
     init = init,
     leave = leave,
+    mark_left = mark_left,
     members = get_members,
     broadcast = broadcast,
     pairs = function() return pairs(get_members()) end,

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -29,6 +29,8 @@ def test_mark_left(servers, helpers):
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'left'])
 
     servers[13302].start()
+    assert servers[13301].conn.eval("return membership.init('localhost', 13302)")[0]
+
     helpers.wait_for(servers[13302].connect)
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'alive'])
     helpers.wait_for(servers[13302].check_status, ['localhost:13301', 'alive'])

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -19,6 +19,7 @@ def test_death(servers, helpers):
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'alive'])
     helpers.wait_for(servers[13302].check_status, ['localhost:13301', 'alive'])
 
+
 def test_mark_left(servers, helpers):
     servers[13302].kill()
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'suspect'])
@@ -31,7 +32,6 @@ def test_mark_left(servers, helpers):
     helpers.wait_for(servers[13302].connect)
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'alive'])
     helpers.wait_for(servers[13302].check_status, ['localhost:13301', 'alive'])
-
 
 
 def test_reinit(servers, helpers):

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -19,6 +19,7 @@ def test_death(servers, helpers):
 
     servers[13302].start()
     helpers.wait_for(servers[13302].connect)
+    assert servers[13301].conn.eval("return membership.init('localhost', 13302)")[0]
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'alive'])
     helpers.wait_for(servers[13302].check_status, ['localhost:13301', 'alive'])
 

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -14,24 +14,11 @@ def test_death(servers, helpers):
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'suspect'])
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'dead'])
 
-    servers[13302].start()
-    helpers.wait_for(servers[13302].connect)
-    helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'alive'])
-    helpers.wait_for(servers[13302].check_status, ['localhost:13301', 'alive'])
-
-
-def test_mark_left(servers, helpers):
-    servers[13302].kill()
-    helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'suspect'])
-    helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'dead'])
-
     assert servers[13301].conn.eval('return membership.mark_left("localhost:13302")')[0]
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'left'])
 
     servers[13302].start()
     helpers.wait_for(servers[13302].connect)
-    assert servers[13301].conn.eval("return membership.init('localhost', 13302)")[0]
-
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'alive'])
     helpers.wait_for(servers[13302].check_status, ['localhost:13301', 'alive'])
 

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -19,6 +19,20 @@ def test_death(servers, helpers):
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'alive'])
     helpers.wait_for(servers[13302].check_status, ['localhost:13301', 'alive'])
 
+def test_mark_left(servers, helpers):
+    servers[13302].kill()
+    helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'suspect'])
+    helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'dead'])
+
+    assert servers[13301].conn.eval('return membership.mark_left("localhost:13302")')[0]
+    helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'left'])
+
+    servers[13302].start()
+    helpers.wait_for(servers[13302].connect)
+    helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'alive'])
+    helpers.wait_for(servers[13302].check_status, ['localhost:13301', 'alive'])
+
+
 
 def test_reinit(servers, helpers):
     assert servers[13301].add_member('localhost:13302')

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -14,12 +14,8 @@ def test_death(servers, helpers):
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'suspect'])
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'dead'])
 
-    assert servers[13301].conn.eval('return membership.mark_left("localhost:13302")')[0]
-    helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'left'])
-
     servers[13302].start()
     helpers.wait_for(servers[13302].connect)
-    assert servers[13301].conn.eval("return membership.init('localhost', 13302)")[0]
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'alive'])
     helpers.wait_for(servers[13302].check_status, ['localhost:13301', 'alive'])
 

--- a/test/test_init.py
+++ b/test/test_init.py
@@ -29,9 +29,9 @@ def test_mark_left(servers, helpers):
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'left'])
 
     servers[13302].start()
+    helpers.wait_for(servers[13302].connect)
     assert servers[13301].conn.eval("return membership.init('localhost', 13302)")[0]
 
-    helpers.wait_for(servers[13302].connect)
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'alive'])
     helpers.wait_for(servers[13302].check_status, ['localhost:13301', 'alive'])
 

--- a/test/test_quit.py
+++ b/test/test_quit.py
@@ -19,3 +19,7 @@ def test_rejoin(servers, helpers):
     assert servers[13302].conn.eval('return membership.init("localhost", 13302)')[0]
     assert servers[13301].add_member('localhost:13302')
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'alive'])
+
+def test_mark_left(servers, helpers):
+    assert servers[13301].conn.eval('return membership.mark_left("localhost:13302")')[0]
+    helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'left'])

--- a/test/test_quit.py
+++ b/test/test_quit.py
@@ -22,5 +22,6 @@ def test_rejoin(servers, helpers):
 
 
 def test_mark_left(servers, helpers):
+    helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'alive'])
     assert servers[13301].conn.eval('return membership.mark_left("localhost:13302")')[0]
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'left'])

--- a/test/test_quit.py
+++ b/test/test_quit.py
@@ -25,3 +25,9 @@ def test_mark_left(servers, helpers):
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'alive'])
     assert servers[13301].conn.eval('return membership.mark_left("localhost:13302")')[0]
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'left'])
+
+    # already has left
+    assert not servers[13301].conn.eval('return membership.mark_left("localhost:13302")')[0]
+
+    # there are no such member
+    assert not servers[13301].conn.eval('return membership.mark_left("localhost:10000")')[0]

--- a/test/test_quit.py
+++ b/test/test_quit.py
@@ -20,6 +20,7 @@ def test_rejoin(servers, helpers):
     assert servers[13301].add_member('localhost:13302')
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'alive'])
 
+
 def test_mark_left(servers, helpers):
     assert servers[13301].conn.eval('return membership.mark_left("localhost:13302")')[0]
     helpers.wait_for(servers[13301].check_status, ['localhost:13302', 'left'])


### PR DESCRIPTION
This pull request introduces a new function `mark_left` to the `membership.lua` file and updates the `CHANGELOG.md` to reflect this addition. The most important changes include the addition of the `mark_left` function and its documentation, as well as the update to the changelog.

### New Functionality:

* [`membership.lua`](diffhunk://#diff-8163f847fe220465ab7e75753b32a07314fbb5a2261b7ee61e56a1c29ace48ddR739-R771): Added the `mark_left` function to mark removed members as `left` and forcefully send a leave message about an instance. [[1]](diffhunk://#diff-8163f847fe220465ab7e75753b32a07314fbb5a2261b7ee61e56a1c29ace48ddR739-R771) [[2]](diffhunk://#diff-8163f847fe220465ab7e75753b32a07314fbb5a2261b7ee61e56a1c29ace48ddR1020)

### Documentation:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R20): Updated the changelog to include the addition of the `mark_left` function.