### PR TITLE
Add new param to forbid adding new members

### DIFF
--- a/membership/events.lua
+++ b/membership/events.lua
@@ -23,6 +23,8 @@ local _expired = table.copy(stash.get('events._expired')) or {
 local _subscribers = table.copy(stash.get('events._subscribers')) or {
     -- [fiber.cond] = true
 }
+local _global_params = stash.get('global_params')
+
 setmetatable(_subscribers, {__mode = 'k'})
 
 function events.after_reload()
@@ -148,7 +150,8 @@ function events.handle(event)
             opts.STATUS_NAMES[event.status]
         )
     end
-    members.set(event.uri, event.status, event.incarnation, { payload = event.payload })
+    members.set(event.uri, event.status, event.incarnation, { payload = event.payload },
+        { forbid_new = _global_params.forbid_new_members })
 
     for cond, _ in pairs(_subscribers) do
         cond:broadcast()

--- a/membership/members.lua
+++ b/membership/members.lua
@@ -84,10 +84,17 @@ function members.filter_excluding(state, uri1, uri2)
     return ret
 end
 
-function members.set(uri, status, incarnation, params)
-    checks('string', 'number', 'number', { payload = '?table', clock_delta = '?number' })
+function members.set(uri, status, incarnation, params, set_opts)
+    checks('string', 'number', 'number',
+        { payload = '?table', clock_delta = '?number', },
+        { forbid_new = '?boolean', }
+    )
 
     local member = _all_members[uri]
+    if member == nil and set_opts and set_opts.forbid_new then
+        opts.log_debug("New member %s was skipped", uri)
+        return
+    end
     if member and incarnation < member.incarnation then
         error('Can not downgrade incarnation')
     end

--- a/membership/stash.lua
+++ b/membership/stash.lua
@@ -1,4 +1,7 @@
 local S = rawget(_G, '__membership_stash') or {}
+S.global_params = S.global_params or {
+    forbid_new_members = false,
+}
 
 local log = require('log')
 


### PR DESCRIPTION
This pull request introduces a new feature to manage the addition of new members in the membership system. The most important changes include adding a global parameter to control the addition of new members, updating the `init` function to accept this parameter, and modifying the `members.set` function to respect this setting.

### New Feature: Control Addition of New Members

* [`membership.lua`](diffhunk://#diff-8163f847fe220465ab7e75753b32a07314fbb5a2261b7ee61e56a1c29ace48ddR40): Introduced `_global_params` to store global configuration parameters and updated the `init` function to accept `forbid_new_members` parameter. This parameter controls whether new members can be added to the group. [[1]](diffhunk://#diff-8163f847fe220465ab7e75753b32a07314fbb5a2261b7ee61e56a1c29ace48ddR40) [[2]](diffhunk://#diff-8163f847fe220465ab7e75753b32a07314fbb5a2261b7ee61e56a1c29ace48ddR607-R622)
* [`membership.lua`](diffhunk://#diff-8163f847fe220465ab7e75753b32a07314fbb5a2261b7ee61e56a1c29ace48ddL487-R489): Updated the `_protocol_step` function to respect the `forbid_new_members` setting when updating member information. [[1]](diffhunk://#diff-8163f847fe220465ab7e75753b32a07314fbb5a2261b7ee61e56a1c29ace48ddL487-R489) [[2]](diffhunk://#diff-8163f847fe220465ab7e75753b32a07314fbb5a2261b7ee61e56a1c29ace48ddL522-R525)

### Codebase Enhancements

* [`membership/events.lua`](diffhunk://#diff-b26c57ba032667f52a479dffd7743724ef07ea10815524ffc66801c9eed9c641R26-R27): Added `global_params` to manage global configuration and updated the `events.handle` function to respect the `forbid_new_members` setting. [[1]](diffhunk://#diff-b26c57ba032667f52a479dffd7743724ef07ea10815524ffc66801c9eed9c641R26-R27) [[2]](diffhunk://#diff-b26c57ba032667f52a479dffd7743724ef07ea10815524ffc66801c9eed9c641L151-R154)
* [`membership/members.lua`](diffhunk://#diff-063a26290f5cf9842fd2af497fbb83370c38718e63d55ca22653b5c8623d9f32R4): Enhanced the `members.set` function to skip adding new members if `forbid_new_members` is set to true and added logging for skipped members. [[1]](diffhunk://#diff-063a26290f5cf9842fd2af497fbb83370c38718e63d55ca22653b5c8623d9f32R4) [[2]](diffhunk://#diff-063a26290f5cf9842fd2af497fbb83370c38718e63d55ca22653b5c8623d9f32L87-R98)
* [`membership/stash.lua`](diffhunk://#diff-eaa23ba7e31b4f641a785fa5466747b0a4757318a9fa6d2a908c923de0ad5e91R2-R4): Initialized `global_params` with a default value for `forbid_new_members`.