### PR TITLE
Fix error in protocol step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Protocol step error when the members list were cleared in process.
+
 ## [2.5.0] - 2025-03-06
 
 ### Added

--- a/membership.lua
+++ b/membership.lua
@@ -514,16 +514,18 @@ local function _protocol_step()
     if sent_indirect > 0 then
         ack_data = wait_ack(uri, loop_now, opts.PROTOCOL_PERIOD_SECONDS * 1.0e6)
     end
+
+    -- check again in case if members list has been cleared
+    local member = members.get(uri)
+    if member == nil then
+        return
+    end
     if sent_indirect > 0 and ack_data ~= nil then
-        local member = members.get(uri)
-        if member == nil then
-            return
-        end
         -- calculate time difference between local time and member time
         local delta = _get_clock_delta(ack_data)
         members.set(uri, member.status, member.incarnation, { clock_delta = delta })
         return
-    elseif members.get(uri).status == opts.ALIVE then
+    elseif member.status == opts.ALIVE then
         local myself = members.get(advertise_uri)
         if myself.status ~= opts.ALIVE then
             opts.log_debug('Could not reach node: %s (%s myself)', uri, myself.status)


### PR DESCRIPTION
This pull request addresses a bug fix related to the protocol step in the membership process. The most important changes include updates to the `CHANGELOG.md` and modifications to the `_protocol_step` function in `membership.lua`.

Bug Fix:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R12): Added a new section under "Fixed" to document the protocol step error when the members list was cleared during the process.

Code Update:

* [`membership.lua`](diffhunk://#diff-8163f847fe220465ab7e75753b32a07314fbb5a2261b7ee61e56a1c29ace48ddL517-R528): Modified the `_protocol_step` function to include a check to handle cases where the members list has been cleared before proceeding with further logic. This ensures the protocol step does not fail unexpectedly.